### PR TITLE
fix: ci release publish after upgrading ci-release-plugin to v1.11.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import sbt.Keys.thisProjectRef
+import xerial.sbt.Sonatype._
 
+ThisBuild / publishTo := sonatypePublishToBundle.value
 ThisBuild / organization := "io.waylay"
 ThisBuild / homepage     := Some(url("https://waylay.io"))
 ThisBuild / developers := List(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,7 @@ addSbtPlugin("com.github.sbt" % "sbt-ghpages"    % "0.8.0")
 addSbtPlugin("org.scoverage"  % "sbt-scoverage"  % "2.3.1")
 addSbtPlugin("org.scoverage"  % "sbt-coveralls"  % "1.3.15")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype"   % "3.12.2")
 
 // scala-xml issues
 // TODO remove when everything has migrated to scala-xml 2.x


### PR DESCRIPTION
@ramazanyich, not sure if this fix will work.
Had a look on https://github.com/sbt/sbt-ci-release/releases/tag/v1.11.0 to use how can still use the legacy OSSRH