### PR TITLE
chore: allow scala-parser-combinators eviction for sbt 1.12.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,6 @@ project/plugins/project/
 .idea
 
 # VsCode extensions
+.bloop
 .metals
+metals*

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,9 @@ val scala2_13 = "2.13.18"
 
 ThisBuild / scalaVersion := scala2_13
 
+ThisBuild / libraryDependencySchemes +=
+  "org.scala-lang.modules" %% "scala-parser-combinators" % VersionScheme.Always
+
 // we need both Test and IntegrationTest scopes for a correct pom, see https://github.com/sbt/sbt/issues/1380
 val TestAndIntegrationTest = IntegrationTest.name + "," + Test.name
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.9
+sbt.version=1.12.10


### PR DESCRIPTION
Replaces https://github.com/waylayio/kairosdb-scala/pull/338