### PR TITLE
fix: run integration tests without forking to avoid Testcontainers shutdown errors

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -27,7 +27,7 @@ jobs:
         NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
       run: mkdir -p $HOME/.config/sbt/2 && echo "credentials += Credentials(\"Sonatype Nexus Repository Manager\", \"nexus.waylay.io\", \"${NEXUS_USER}\", \"${NEXUS_PASSWORD}\")" > $HOME/.config/sbt/2/global.sbt
     - name: Run tests
-      run: sbt ";clean;test;integration/test"
+      run: sbt ";clean;testFull;integration/testFull"
     - name: Publish
       if: ${{ github.event_name != 'pull_request' }}
       run: sbt +publish

--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,6 @@ lazy val integration = (project in file("integration"))
   .settings(
     name                     := "kairosdb-scala-integration-tests",
     publish / skip           := true,
-    Test / fork              := true,
     Test / parallelExecution := false,
     Test / baseDirectory     := (LocalRootProject / baseDirectory).value,
     Test / scalaSource       := (LocalRootProject / baseDirectory).value / "src" / "it" / "scala",


### PR DESCRIPTION
Should fix shutdown error when running tests (after migrating to sbt 2.x). See https://github.com/waylayio/kairosdb-scala/actions/runs/29394041502/job/87283433113

```
...
[info] The health status
[info] - should fail without auth
[info] - should succeed with auth
[info] VersionIntegrationSpec:
[info] Getting the KairosDB version
[info] - should return version
Error: Exception in thread "Thread-3" java.lang.NoClassDefFoundError: org/testcontainers/utility/PathUtils
	at org.testcontainers.utility.MountableFile.lambda$deleteOnExit$0(MountableFile.java:318)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.ClassNotFoundException: org.testcontainers.utility.PathUtils
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:592)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	... 2 more
[info] Run completed in 46 seconds, 687 milliseconds.
[info] Total number of tests run: 14
[info] Suites: completed 9, aborted 0
[info] Tests: succeeded 14, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] elapsed time: 74 s (0:01:14.0)
...
```